### PR TITLE
In Row::isModified(), compare bools as ints

### DIFF
--- a/src/Row.php
+++ b/src/Row.php
@@ -192,8 +192,13 @@ abstract class Row implements IteratorAggregate, JsonSerializable
 
     protected function isModified(string $col) : bool
     {
-        $old = $this->init[$col];
-        $new = $this->cols[$col];
+        $old = is_bool($this->init[$col])
+            ? (int) $this->init[$col]
+            : $this->init[$col];
+
+        $new = is_bool($this->cols[$col])
+            ? (int) $this->cols[$col]
+            : $this->cols[$col];
 
         return (is_numeric($old) && is_numeric($new))
             ? $old != $new // numeric, compare loosely

--- a/tests/RowTest.php
+++ b/tests/RowTest.php
@@ -162,4 +162,44 @@ class RowTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEmpty($init);
     }
+
+    public function testIsModified_numericToBool()
+    {
+        $init = [
+            'id' => 1,
+            'name' => 'foo',
+            'building' => 'bar',
+            'floor' => 1,
+        ];
+
+        $row = new EmployeeRow($init);
+
+        $row->floor = true;
+        $diff = $row->getArrayDiff();
+        $this->assertEmpty($diff);
+
+        $row->floor = false;
+        $diff = $row->getArrayDiff();
+        $this->assertSame(['floor' => false], $diff);
+    }
+
+    public function testIsModified_boolToNumeric()
+    {
+        $init = [
+            'id' => 1,
+            'name' => 'foo',
+            'building' => 'bar',
+            'floor' => true,
+        ];
+
+        $row = new EmployeeRow($init);
+
+        $row->floor = 1;
+        $diff = $row->getArrayDiff();
+        $this->assertEmpty($diff);
+
+        $row->floor = 0;
+        $diff = $row->getArrayDiff();
+        $this->assertSame(['floor' => 0], $diff);
+    }
 }


### PR DESCRIPTION
This should help reduce ""Expected 1 row affected, actual 0" errors when the Row array diff indicates a change from true to 1, or false to 0, and vice versa.
