### PR TITLE
Only perform update/delete when a primary key is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.4.0
+
+The methods Table::updateRowPerform() and deleteRowPerform() now throw an
+exception when the table does not have a primary key.
+
 ## 1.3.0
 
 This release implements IteratorAggregate on Row objects so you can foreach()

--- a/docs/events.md
+++ b/docs/events.md
@@ -63,6 +63,14 @@ function afterDeleteRow(
 ) : void
 ```
 
+> **Note:**
+>
+> The methods `beforeInsertRow()` and `beforeUpdateRow()` optionally return an
+> array. If they return an array, that array's key-value pairs will be used for
+> the insert or update. Otherwise, the difference between the Row's previous
+> values and its current values will be calculated, and their difference will be
+> used for the insert or update.
+
 For example, when you call `Table::updateRow()`, these events run in this order:
 
 - `beforeUpdateRow()`

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -33,27 +33,39 @@ class Exception extends \Exception
         return new Exception("Expected type $expect; got $actual instead.");
     }
 
-    public static function unexpectedRowCountAffected($count)
+    public static function unexpectedRowCountAffected($count) : Exception
     {
         return new Exception("Expected 1 row affected, actual {$count}.");
     }
 
-    public static function immutableOnceDeleted(string $class, string $property)
+    public static function immutableOnceDeleted(string $class, string $property) : Exception
     {
         return new Exception("{$class}::\${$property} is immutable after Row is deleted.");
     }
 
-    public static function primaryValueNotScalar(string $col, $val)
+    public static function primaryValueNotScalar(string $col, $val) : Exception
     {
         $message = "Expected scalar value for primary key '{$col}', "
             . "got " . gettype($val) . " instead.";
         return new Exception($message);
     }
 
-    public static function primaryValueMissing(string $col)
+    public static function primaryValueMissing(string $col) : Exception
     {
         $message = "Expected scalar value for primary key '$col', "
             . "value is missing instead.";
+        return new Exception($message);
+    }
+
+    public static function primaryValueChanged(string $col) : Exception
+    {
+        $message = "Primary key value for '$col' changed";
+        return new Exception($message);
+    }
+
+    public static function cannotPerformWithoutPrimaryKey(string $operation, string $table) : Exception
+    {
+        $message = "Cannot {$operation} on table '$table' without primary key.";
         return new Exception($message);
     }
 
@@ -62,7 +74,7 @@ class Exception extends \Exception
         return new Exception("Table already set.");
     }
 
-    public static function unexpectedOption($value, array $options)
+    public static function unexpectedOption($value, array $options) : Exception
     {
         $message = "Expected one of '" . implode("','", $options)
             . "'; got '{$value}' instead.";

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -33,24 +33,24 @@ class Exception extends \Exception
         return new Exception("Expected type $expect; got $actual instead.");
     }
 
-    public static function unexpectedRowCountAffected($count) : Exception
+    public static function unexpectedRowCountAffected($count)
     {
         return new Exception("Expected 1 row affected, actual {$count}.");
     }
 
-    public static function immutableOnceDeleted(string $class, string $property) : Exception
+    public static function immutableOnceDeleted(string $class, string $property)
     {
         return new Exception("{$class}::\${$property} is immutable after Row is deleted.");
     }
 
-    public static function primaryValueNotScalar(string $col, $val) : Exception
+    public static function primaryValueNotScalar(string $col, $val)
     {
         $message = "Expected scalar value for primary key '{$col}', "
             . "got " . gettype($val) . " instead.";
         return new Exception($message);
     }
 
-    public static function primaryValueMissing(string $col) : Exception
+    public static function primaryValueMissing(string $col)
     {
         $message = "Expected scalar value for primary key '$col', "
             . "value is missing instead.";
@@ -74,7 +74,7 @@ class Exception extends \Exception
         return new Exception("Table already set.");
     }
 
-    public static function unexpectedOption($value, array $options) : Exception
+    public static function unexpectedOption($value, array $options)
     {
         $message = "Expected one of '" . implode("','", $options)
             . "'; got '{$value}' instead.";

--- a/src/Table.php
+++ b/src/Table.php
@@ -56,7 +56,7 @@ abstract class Table
         $this->queryFactory = $queryFactory;
         $this->tableEvents = $tableEvents;
         $this->rowClass = substr(static::CLASS, 0, -5) . 'Row';
-        if (count($this::PRIMARY_KEY) < 2) {
+        if (count($this::PRIMARY_KEY) == 1) {
             $this->primaryKey = new PrimarySimple($this::PRIMARY_KEY[0]);
         } else {
             $this->primaryKey = new PrimaryComposite($this::PRIMARY_KEY);

--- a/src/Table.php
+++ b/src/Table.php
@@ -199,7 +199,7 @@ abstract class Table
         }
 
         if (empty(static::PRIMARY_KEY)) {
-            throw Exception::cannotPerformWithoutPrimaryKey('update', static::NAME);
+            throw Exception::cannotPerformWithoutPrimaryKey('update row', static::NAME);
         }
 
         $pdoStatement = $update->perform();
@@ -249,7 +249,7 @@ abstract class Table
         }
 
         if (empty(static::PRIMARY_KEY)) {
-            throw Exception::cannotPerformWithoutPrimaryKey('delete', static::NAME);
+            throw Exception::cannotPerformWithoutPrimaryKey('delete row', static::NAME);
         }
 
         $pdoStatement = $delete->perform();

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -8,6 +8,8 @@ use Atlas\Testing\CompositeDataSource\Course\CourseTable;
 use Atlas\Testing\CompositeDataSourceFixture;
 use Atlas\Testing\DataSource\Employee\EmployeeRow;
 use Atlas\Testing\DataSource\Employee\EmployeeTable;
+use Atlas\Testing\DataSource\Nopkey\NopkeyRow;
+use Atlas\Testing\DataSource\Nopkey\NopkeyTable;
 use Atlas\Testing\DataSourceFixture;
 use PDO;
 use PDOStatement;
@@ -388,5 +390,37 @@ class TableTest extends \PHPUnit\Framework\TestCase
     {
         $conn = $this->table->getWriteConnection();
         $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+    }
+
+    public function testUpdateRow_noPrimaryKey()
+    {
+        $table = $this->tableLocator->get(NopkeyTable::CLASS);
+        $row = $table->newRow([
+            'name' => 'Bolivar Shagnasty',
+            'email' => 'boshag@example.com',
+        ]);
+        $table->insertRow($row);
+
+        $row->email = 'boshag@example.org';
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage("Cannot update row on table 'nopkeys' without primary key.");
+
+        $table->updateRow($row);
+    }
+
+    public function testDeleteRow_noPrimaryKey()
+    {
+        $table = $this->tableLocator->get(NopkeyTable::CLASS);
+        $row = $table->newRow([
+            'name' => 'Bolivar Shagnasty',
+            'email' => 'boshag@example.com',
+        ]);
+        $table->insertRow($row);
+
+        $row->email = 'boshag@example.org';
+        $this->expectException(Exception::CLASS);
+        $this->expectExceptionMessage("Cannot delete row on table 'nopkeys' without primary key.");
+
+        $table->deleteRow($row);
     }
 }


### PR DESCRIPTION
Fixes #9 