### PR TITLE
Updates the documentation on creating and inserting a row to use the table object and not the atlas instance

### DIFF
--- a/docs/writing.md
+++ b/docs/writing.md
@@ -6,7 +6,7 @@ Create a new Row using the `newRow()` method. You can assign data using
 properties, or pass an array of initial data to populate into the Row.
 
 ```php
-$threadRow = $atlas->newRow([
+$threadRow = $threadTable->newRow([
     'title' => 'New Thread Title',
 ]);
 ```


### PR DESCRIPTION
Only the class `Atlas\Table\Table` has the method `newRow` and an Atlas instance is not present here:

```php
$threadRow = $atlas->newRow([
    'title' => 'New Thread Title',
]);
```
vs.
```php
$threadRow = $threadTable->newRow([
    'title' => 'New Thread Title',
]);
```

https://atlasphp.io/cassini/table/writing.html#2-3-3-1