### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=8.1.0",
         "atlas/pdo": "~1.0",
         "atlas/query": "~1.0"
     },
@@ -24,7 +24,7 @@
     "require-dev": {
         "atlas/testing": "~1.0",
         "pds/skeleton": "~1.0",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "~10.0 || ~11.0 || ~12.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="phpunit.php">
-    <testsuites>
-        <testsuite name="atlas/table">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="phpunit.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="atlas/table">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="phpunit.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="phpunit.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="atlas/table">
       <directory>tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/TableLocator.php
+++ b/src/TableLocator.php
@@ -20,7 +20,7 @@ class TableLocator
 
     protected $factory;
 
-    protected $tables = [];
+    protected $instances = [];
 
     public static function new(...$args) : TableLocator
     {

--- a/src/TableLocator.php
+++ b/src/TableLocator.php
@@ -33,7 +33,7 @@ class TableLocator
     public function __construct(
         ConnectionLocator $connectionLocator,
         TableQueryFactory $tableQueryFactory,
-        callable $factory = null
+        ?callable $factory = null
     ) {
         $this->connectionLocator = $connectionLocator;
         $this->tableQueryFactory = $tableQueryFactory;

--- a/tests/TableLocatorTest.php
+++ b/tests/TableLocatorTest.php
@@ -9,7 +9,9 @@ use Atlas\Testing\DataSourceFixture;
 
 class TableLocatorTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected $tableLocator;
+
+    protected function setUp() : void
     {
         $connection = (new DataSourceFixture())->exec();
         $this->tableLocator = TableLocator::new($connection);

--- a/tests/TableSelectTest.php
+++ b/tests/TableSelectTest.php
@@ -31,7 +31,7 @@ class TableSelectTest extends \PHPUnit\Framework\TestCase
         // success
         $actual = $this->select->where('id = ', '1')->fetchRow();
         $this->assertInstanceOf(EmployeeRow::CLASS, $actual);
-        $this->assertSame($expect, $actual->getArrayCopy());
+        $this->assertSame($expect, array_map('strval', $actual->getArrayCopy()));
 
         // failure
         $actual = $this->select->where('id = ', '-1')->fetchRow();
@@ -64,9 +64,9 @@ class TableSelectTest extends \PHPUnit\Framework\TestCase
         // success
         $actual = $this->select->where('id IN ', [1, 2, 3])->fetchRows();
         $this->assertCount(3, $actual);
-        $this->assertSame($expect[0], $actual[0]->getArrayCopy());
-        $this->assertSame($expect[1], $actual[1]->getArrayCopy());
-        $this->assertSame($expect[2], $actual[2]->getArrayCopy());
+        $this->assertSame($expect[0], array_map('strval', $actual[0]->getArrayCopy()));
+        $this->assertSame($expect[1], array_map('strval', $actual[1]->getArrayCopy()));
+        $this->assertSame($expect[2], array_map('strval', $actual[2]->getArrayCopy()));
 
         // failure
         $actual = $this->select->where('id IN ', [997, 998, 999])->fetchRows();

--- a/tests/TableSelectTest.php
+++ b/tests/TableSelectTest.php
@@ -12,7 +12,7 @@ class TableSelectTest extends \PHPUnit\Framework\TestCase
 
     protected $table;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $connection = (new DataSourceFixture())->exec();
         $this->table = TableLocator::new($connection)->get(EmployeeTable::CLASS);

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -65,7 +65,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->logQueries();
         $row = $this->table->fetchRow(1);
         $this->assertInstanceOf(EmployeeRow::CLASS, $row);
-        $this->assertSame($expect, $row->getArrayCopy());
+        $this->assertSame($expect, array_map('strval', $row->getArrayCopy()));
 
         // check quoting
         $queries = $this->getQueries();
@@ -101,7 +101,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
             'course_number' => '100'
         ]);
 
-        $this->assertSame($expect, $actual->getArrayCopy());
+        $this->assertSame($expect, array_map('strval', $actual->getArrayCopy()));
 
         // check quoting
         $queries = $this->getQueries();
@@ -174,9 +174,9 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(EmployeeRow::CLASS, $actual[0]);
         $this->assertInstanceOf(EmployeeRow::CLASS, $actual[1]);
         $this->assertInstanceOf(EmployeeRow::CLASS, $actual[2]);
-        $this->assertSame($expect[0], $actual[0]->getArrayCopy());
-        $this->assertSame($expect[1], $actual[1]->getArrayCopy());
-        $this->assertSame($expect[2], $actual[2]->getArrayCopy());
+        $this->assertSame($expect[0], array_map('strval', $actual[0]->getArrayCopy()));
+        $this->assertSame($expect[1], array_map('strval', $actual[1]->getArrayCopy()));
+        $this->assertSame($expect[2], array_map('strval', $actual[2]->getArrayCopy()));
 
         // check quoting
         $queries = $this->getQueries();
@@ -224,9 +224,9 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(CourseRow::CLASS, $actual[0]);
         $this->assertInstanceOf(CourseRow::CLASS, $actual[1]);
         $this->assertInstanceOf(CourseRow::CLASS, $actual[2]);
-        $this->assertSame($expect[0], $actual[0]->getArrayCopy());
-        $this->assertSame($expect[1], $actual[1]->getArrayCopy());
-        $this->assertSame($expect[2], $actual[2]->getArrayCopy());
+        $this->assertSame($expect[0], array_map('strval', $actual[0]->getArrayCopy()));
+        $this->assertSame($expect[1], array_map('strval', $actual[1]->getArrayCopy()));
+        $this->assertSame($expect[2], array_map('strval', $actual[2]->getArrayCopy()));
 
         // check quoting
         $queries = $this->getQueries();
@@ -287,6 +287,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
         $actual = $this->table->getReadConnection()->fetchOne(
             'SELECT * FROM employee WHERE id = 13'
         );
+        $actual = array_map('strval', $actual);
         $this->assertSame($expect, $actual);
 
         // try to insert again, should fail on unique name

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -22,7 +22,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
 
     protected $tableLocator;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $connection = (new DataSourceFixture())->exec();
         (new CompositeDataSourceFixture($connection))->exec();


### PR DESCRIPTION
Updates for php8.

- phpunit 9
- avoid dynamic properties (i think tables/instances was just a mistake)
- php8.1 PDO returns ints as ints, not strings. This just casts actual results to strings. Its hacky, but it wasnt testing type reality anyway.